### PR TITLE
Hotfix: non normalized hists

### DIFF
--- a/skrmt/ensemble/spectral_law.py
+++ b/skrmt/ensemble/spectral_law.py
@@ -320,7 +320,7 @@ class WignerSemicircleDistribution:
             raise ValueError("matrix size must be positive")
         
         if interval is None:
-            interval = (-self.radius, self.radius)
+            interval = (self.center - self.radius, self.center + self.radius)
 
         random_samples = self.rvs(size=n_size)
         observed, bins = np.histogram(random_samples, bins=bins, range=interval, density=density)

--- a/skrmt/ensemble/tests/test_gaussian_ens.py
+++ b/skrmt/ensemble/tests/test_gaussian_ens.py
@@ -82,9 +82,9 @@ def test_goe_build_tridiagonal():
     goe = GaussianEnsemble(beta=1, n=n_size, use_tridiagonal=True)
 
     np.random.seed(1)
-    normals = (1/np.sqrt(2)) * np.random.normal(loc=0, scale=np.sqrt(2), size=n_size)
+    normals = np.random.normal(loc=0, scale=1, size=n_size)
     dfs = np.flip(np.arange(1, n_size))
-    chisqs = (1/np.sqrt(2)) * np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
+    chisqs = np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
 
     for i in range(n_size):
         assert normals[i] == goe.matrix[i][i]
@@ -217,9 +217,9 @@ def test_gue_build_tridiagonal():
     gue = GaussianEnsemble(beta=2, n=n_size, use_tridiagonal=True)
 
     np.random.seed(1)
-    normals = (1/np.sqrt(2)) * np.random.normal(loc=0, scale=np.sqrt(2), size=n_size)
+    normals = np.random.normal(loc=0, scale=1, size=n_size)
     dfs = np.flip(np.arange(1, n_size))
-    chisqs = (1/np.sqrt(2)) * np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
+    chisqs = np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
 
     for i in range(n_size):
         assert normals[i] == gue.matrix[i][i]
@@ -272,16 +272,14 @@ def test_gse_init():
 
     assert gse.matrix.shape == (2*n_size,2*n_size)
 
-    mtx_sol = [[2.29717124+0.j, -0.80605094-2.86120185j,\
-                0.+0.j, -1.21019792-1.0732635j],
-               [-0.80605094+2.86120185j, -1.51740678+0.j,\
-                1.21019792+1.0732635j, 0.+0.j],
-               [0.+0.j, 1.21019792-1.0732635j,\
-                2.29717124+0.j, -0.80605094+2.86120185j],
-               [-1.21019792+1.0732635j, 0.+0.j,\
-                -0.80605094-2.86120185j, -1.51740678+0.j]]
+    mtx_sol = [
+        [3.24869073+0.j, -1.13992817-4.04635046j, 0.+0.j, -1.71147831-1.5178238j],
+        [-1.13992817+4.04635046j, -2.14593724+0.j, 1.71147831+1.5178238j, 0.+0.j],
+        [0.+0.j, 1.71147831-1.5178238j, 3.24869073+0.j, -1.13992817+4.04635046j],
+        [-1.71147831+1.5178238j, 0.+0.j, -1.13992817-4.04635046j, -2.14593724+0.j],
+    ]
 
-    assert_almost_equal(gse.matrix, np.array(mtx_sol),
+    assert_almost_equal(gse.matrix, np.asarray(mtx_sol),
                         decimal=4)
 
 
@@ -325,9 +323,9 @@ def test_gse_build_tridiagonal():
 
     np.random.seed(1)
     n_size *= 2  # WQE matrices are 2p times 2p
-    normals = (1/np.sqrt(2)) * np.random.normal(loc=0, scale=np.sqrt(2), size=n_size)
+    normals = np.random.normal(loc=0, scale=1, size=n_size)
     dfs = np.flip(np.arange(1, n_size))
-    chisqs = (1/np.sqrt(2)) * np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
+    chisqs = np.array([np.sqrt(np.random.chisquare(df*beta)) for df in dfs])
 
     for i in range(n_size):
         assert normals[i] == gse.matrix[i][i]

--- a/skrmt/ensemble/wishart_ensemble.py
+++ b/skrmt/ensemble/wishart_ensemble.py
@@ -100,6 +100,13 @@ class WishartEnsemble(_Ensemble):
         self.matrix = self.sample()
         # default eigenvalue normalization constant
         self.eigval_norm_const = 1/self.n
+        self._compute_parameters()
+
+    def _compute_parameters(self):
+        # calculating constants depending on matrix sizes
+        self.ratio = self.p/self.n
+        self.lambda_plus = self.beta * self.sigma**2 * (1 + np.sqrt(self.ratio))**2
+        self.lambda_minus = self.beta * self.sigma**2 * (1 - np.sqrt(self.ratio))**2
 
     def set_size(self, p, n, resample_mtx=True):
         # pylint: disable=arguments-differ
@@ -118,6 +125,7 @@ class WishartEnsemble(_Ensemble):
         """
         self.p = p
         self.n = n
+        self._compute_parameters()
         if resample_mtx:
             self.matrix = self.sample()
 
@@ -306,16 +314,12 @@ class WishartEnsemble(_Ensemble):
                 Journal of Mathematical Physics. 43.11 (2002): 5830-5847.
 
         """
-        if not normalize:
-            print("Warning: setting normalize=False may cause normal instability and/or rounding errors.")
-
         # pylint: disable=too-many-arguments
         if interval is None:
-            # calculating constants depending on matrix sizes
-            ratio = self.p/self.n
-            lambda_plus = self.beta * self.sigma**2 * (1 + np.sqrt(ratio))**2
-            lambda_minus = self.beta * self.sigma**2 * (1 - np.sqrt(ratio))**2
-            interval = (lambda_minus, lambda_plus)
+            if normalize:
+                interval = (self.lambda_minus, self.lambda_plus)
+            else:
+                interval = (self.n*self.lambda_minus, self.n*self.lambda_plus)
 
         if self.use_tridiagonal:
             observed, bins = self.eigval_hist(


### PR DESCRIPTION
Fixed **non-normalized eigenvalues histograms**. Now the histograms are illustrated correctly when the eigenvalues are not normalized. The **plot interval is updated depending on additional parameters, such as matrix size** `n`.
In addition, there was a bug were the distribution of the tridiagonal random matrices was not the same as its non-tridiagonalized form when the eigenvalues were not normalized. This has been fixed in this PR.