### PR TITLE
Feature: plot eigval hist separately

### DIFF
--- a/skrmt/ensemble/base_ensemble.py
+++ b/skrmt/ensemble/base_ensemble.py
@@ -170,6 +170,14 @@ class _Ensemble(metaclass=ABCMeta):
         observed, bin_edges = np.histogram(eigvals, bins=bins, range=interval, density=density)
         return observed, bin_edges
 
+    def _plot_eigval_hist(self, bins, interval=None, density=False, normalize=False, avoid_img=False):
+        # computing eigenvalue histogram
+        observed, bin_edges = self.eigval_hist(bins=bins, interval=interval, density=density,
+                                               normalize=normalize, avoid_img=avoid_img)
+        # plotting eigenvalue histogram
+        width = bin_edges[1]-bin_edges[0]
+        plt.bar(bin_edges[:-1], observed, width=width, align='edge')
+        return observed, bin_edges
 
     def plot_eigval_hist(
         self,
@@ -227,17 +235,18 @@ class _Ensemble(metaclass=ABCMeta):
             if not isinstance(interval, tuple):
                 raise ValueError("interval argument must be a tuple")
 
-        observed, bin_edges = self.eigval_hist(bins=bins, interval=interval, density=density,
-                                               normalize=normalize, avoid_img=avoid_img)
-        width = bin_edges[1]-bin_edges[0]
-        plt.bar(bin_edges[:-1], observed, width=width, align='edge')
+        # histogramming and plotting
+        observed, bin_edges = self._plot_eigval_hist(
+            bins=bins, interval=interval, density=density, normalize=normalize, avoid_img=avoid_img
+        )
 
+        # plot labels, title and illustration
         plt.title("Eigenvalue histogram", fontweight="bold")
         plt.xlabel("x")
         plt.ylabel("density")
 
         # Saving plot or showing it
         if savefig_path:
-            plt.savefig(savefig_path, dpi=1200)
+            plt.savefig(savefig_path, dpi=1000)
         else:
             plt.show()

--- a/skrmt/ensemble/gaussian_ensemble.py
+++ b/skrmt/ensemble/gaussian_ensemble.py
@@ -9,7 +9,6 @@ Gaussian Unitary Ensemble (GUE) and Gaussian Symplectic Ensemble (GSE).
 
 import numpy as np
 from scipy import sparse, special
-import matplotlib.pyplot as plt
 
 from .base_ensemble import _Ensemble
 from .tridiagonal_utils import tridiag_eigval_hist

--- a/skrmt/ensemble/gaussian_ensemble.py
+++ b/skrmt/ensemble/gaussian_ensemble.py
@@ -107,7 +107,7 @@ class GaussianEnsemble(_Ensemble):
         }
 
         # scikit-rmt class implementing the corresponding spectral law
-        self._law_class = WignerSemicircleDistribution(beta=self.beta, center=0.0, sigma=self.sigma) 
+        self._law_class = WignerSemicircleDistribution(beta=self.beta, center=0.0, sigma=self.sigma)
 
     def set_size(self, n, resample_mtx=True, random_state: int = None):
         # pylint: disable=arguments-differ

--- a/skrmt/ensemble/gaussian_ensemble.py
+++ b/skrmt/ensemble/gaussian_ensemble.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 
 from .base_ensemble import _Ensemble
 from .tridiagonal_utils import tridiag_eigval_hist
+from .spectral_law import WignerSemicircleDistribution
 
 #########################################################################
 ### Gaussian Ensemble = Hermite Ensemble
@@ -104,6 +105,9 @@ class GaussianEnsemble(_Ensemble):
             2: (-2*np.sqrt(2*self.n), 2*np.sqrt(2*self.n)),
             4: (-4*np.sqrt(2*self.n), 4*np.sqrt(2*self.n)),
         }
+
+        # scikit-rmt class implementing the corresponding spectral law
+        self._law_class = WignerSemicircleDistribution(beta=self.beta, center=0.0, sigma=self.sigma) 
 
     def set_size(self, n, resample_mtx=True, random_state: int = None):
         # pylint: disable=arguments-differ
@@ -259,6 +263,12 @@ class GaussianEnsemble(_Ensemble):
         return norm_const * self._eigvals
 
     def eigval_hist(self, bins, interval=None, density=False, normalize=False, avoid_img=False):
+        if interval is None:
+            if normalize:
+                interval = (-self.radius, self.radius)
+            else:
+                interval = self._non_normalized_interval[self.beta]
+
         if self.use_tridiagonal:
             if normalize:
                 return tridiag_eigval_hist(
@@ -269,8 +279,9 @@ class GaussianEnsemble(_Ensemble):
                 )
             return tridiag_eigval_hist(self.matrix, bins=bins, interval=interval, density=density)
 
-        return super().eigval_hist(bins, interval=interval, density=density,
-                                   normalize=normalize, avoid_img=avoid_img)
+        return super().eigval_hist(
+            bins, interval=interval, density=density, normalize=normalize, avoid_img=avoid_img
+        )
 
     def plot_eigval_hist(self, bins=100, interval=None, density=False, normalize=False, savefig_path=None):
         """Computes and plots the histogram of the matrix eigenvalues.
@@ -308,38 +319,14 @@ class GaussianEnsemble(_Ensemble):
                 Journal of Mathematical Physics. 43.11 (2002): 5830-5847.
 
         """
-        if interval is None:
-            if normalize:
-                interval = (-self.radius, self.radius)
-            else:
-                interval = self._non_normalized_interval[self.beta]
-
-        if self.use_tridiagonal:
-            # pylint: disable=too-many-arguments
-            observed, bin_edges = self.eigval_hist(
-                bins=bins, interval=interval, density=density, normalize=normalize
-            )
-            width = bin_edges[1]-bin_edges[0]
-            plt.bar(bin_edges[:-1], observed, width=width, align='edge')
-
-            plt.title("Eigenvalue histogram", fontweight="bold")
-            plt.xlabel("x")
-            plt.ylabel("density")
-            # Saving plot or showing it
-            if savefig_path:
-                plt.savefig(savefig_path, dpi=1000)
-            else:
-                plt.show()
-
-        else:
-            # pylint: disable=too-many-arguments
-            super().plot_eigval_hist(
-                bins=bins,
-                interval=interval,
-                density=density,
-                normalize=normalize,
-                savefig_path=savefig_path,
-            )
+        # the default interval will be computed in the method `eigval_hist` if the given interval is None
+        super().plot_eigval_hist(
+            bins=bins,
+            interval=interval,
+            density=density,
+            normalize=normalize,
+            savefig_path=savefig_path,
+        )
 
     def joint_eigval_pdf(self, eigvals=None):
         '''Computes joint eigenvalue pdf.

--- a/skrmt/ensemble/manova_ensemble.py
+++ b/skrmt/ensemble/manova_ensemble.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy import special
 
 from .base_ensemble import _Ensemble
+from .spectral_law import ManovaSpectrumDistribution
 
 
 #########################################################################
@@ -95,6 +96,10 @@ class ManovaEnsemble(_Ensemble):
         self.beta = beta
         self._eigvals = None
         self.matrix = self.sample(random_state=random_state)
+        # scikit-rmt class implementing the corresponding spectral law
+        self._law_class = ManovaSpectrumDistribution(
+            beta=self.beta, ratio_a=self.n1/self.m, ratio_b=self.n2/self.m
+        )
 
     def set_size(self, m, n1, n2, resample_mtx=True, random_state: int = None):
         # pylint: disable=arguments-differ

--- a/skrmt/ensemble/tests/test_utils.py
+++ b/skrmt/ensemble/tests/test_utils.py
@@ -6,8 +6,12 @@ import os
 import pytest
 import shutil
 
-from skrmt.ensemble.utils import rand_mtx_max_eigvals, plot_max_eigvals_tracy_widom
 from skrmt.ensemble.gaussian_ensemble import GaussianEnsemble
+from skrmt.ensemble.utils import (
+    rand_mtx_max_eigvals,
+    plot_spectral_hist_and_law,
+    plot_max_eigvals_tracy_widom,
+)
 
 
 TMP_DIR_PATH = os.path.join(os.getcwd(), "skrmt/ensemble/tests/tmp")
@@ -39,6 +43,21 @@ def _remove_tmp_dir():
 
 
 class TestUtils:
+
+    def test_plot_spectral_hist_and_law(self):
+        """Testing plotting the spectral histogram of a random matrix ensemble
+        alongside the PDF of the corresponding spectral law.
+        """
+        fig_name = "test_test_plot_spectral_hist_and_law.png"
+
+        goe = GaussianEnsemble(beta=1, n=10, random_state=1)
+        plot_spectral_hist_and_law(
+            ensemble=goe,
+            bins=20,
+            savefig_path=TMP_DIR_PATH+"/"+fig_name,
+        )
+        assert os.path.isfile(os.path.join(TMP_DIR_PATH, fig_name)) == True
+
 
     def test_rand_mtx_max_eigvals(self):
         """Testing getting maximum eigenvalues of an Ensemble object

--- a/skrmt/ensemble/utils.py
+++ b/skrmt/ensemble/utils.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from .base_ensemble import _Ensemble
 from .gaussian_ensemble import GaussianEnsemble
 from .tracy_widom_approximator import TW_Approximator
-from .spectral_law import WignerSemicircleDistribution
 from .misc import get_bins_centers_and_contour
 
 
@@ -19,13 +18,17 @@ def plot_spectral_hist_and_law(
     bins: Union[int, Sequence] = 100,
     savefig_path: str = None,
 ):
-    
-    ens = GaussianEnsemble(n=1000, beta=1, random_state=1) # this would be pre-defined
-    observed, bin_edges = ens._plot_eigval_hist(bins=bins, density=True, normalize=True)
-
-    law_class = ens._law_class
+    """TODO
+    """
+    # plotting ensemble spectral histogram
+    observed, bin_edges = ensemble._plot_eigval_hist(bins=bins, density=True, normalize=True)
     centers = np.asarray(get_bins_centers_and_contour(bin_edges))
+
+    # getting the class that implements the ensemble spectral law
+    law_class = ensemble._law_class
+    # computing PDF on the bin centers
     pdf = law_class.pdf(centers)
+    # plotting PDF
     plt.plot(centers, pdf, color='red', linewidth=2)
 
     # Saving plot or showing it
@@ -33,7 +36,6 @@ def plot_spectral_hist_and_law(
         plt.savefig(savefig_path, dpi=1200)
     else:
         plt.show()
-
 
 
 def plot_max_eigvals_tracy_widom(

--- a/skrmt/ensemble/utils.py
+++ b/skrmt/ensemble/utils.py
@@ -8,8 +8,32 @@ from typing import Union, Sequence
 import matplotlib.pyplot as plt
 
 from .base_ensemble import _Ensemble
+from .gaussian_ensemble import GaussianEnsemble
 from .tracy_widom_approximator import TW_Approximator
+from .spectral_law import WignerSemicircleDistribution
 from .misc import get_bins_centers_and_contour
+
+
+def plot_spectral_hist_and_law(
+    ensemble: _Ensemble,
+    bins: Union[int, Sequence] = 100,
+    savefig_path: str = None,
+):
+    
+    ens = GaussianEnsemble(n=1000, beta=1, random_state=1) # this would be pre-defined
+    observed, bin_edges = ens._plot_eigval_hist(bins=bins, density=True, normalize=True)
+
+    law_class = ens._law_class
+    centers = np.asarray(get_bins_centers_and_contour(bin_edges))
+    pdf = law_class.pdf(centers)
+    plt.plot(centers, pdf, color='red', linewidth=2)
+
+    # Saving plot or showing it
+    if savefig_path:
+        plt.savefig(savefig_path, dpi=1200)
+    else:
+        plt.show()
+
 
 
 def plot_max_eigvals_tracy_widom(
@@ -70,7 +94,6 @@ def plot_max_eigvals_tracy_widom(
         plt.savefig(savefig_path, dpi=1200)
     else:
         plt.show()
-
 
 
 def rand_mtx_max_eigvals(

--- a/skrmt/ensemble/utils.py
+++ b/skrmt/ensemble/utils.py
@@ -8,7 +8,6 @@ from typing import Union, Sequence
 import matplotlib.pyplot as plt
 
 from .base_ensemble import _Ensemble
-from .gaussian_ensemble import GaussianEnsemble
 from .tracy_widom_approximator import TW_Approximator
 from .misc import get_bins_centers_and_contour
 
@@ -18,7 +17,25 @@ def plot_spectral_hist_and_law(
     bins: Union[int, Sequence] = 100,
     savefig_path: str = None,
 ):
-    """TODO
+    """Plots the spectrum histogram of a random matrix ensemble alongside the
+    PDF of the corresponding spectral law.
+
+    It illustrates the histogram of the spectrum of a given random matrix ensemble
+    alongside the PDF of the corresponding spectral law, i.e.:
+    - If `ensemble` is `GaussianEnsemble` then is plotted Wigner's Semicircle law PDF.
+    - If `ensemble` is `WishartEnsemble` then is plotted Marchenko-Pastur law PDF.
+    - If `ensemble` is `ManovaEnsemble` then is plotted the PDF of the Manova ensemble
+    formulated by Wachter.
+
+    Args:
+        ensemble (_Ensemble): a random matrix ensemble instance. The only supported types
+            are `GaussianEnsemble`, `WishartEnsemble` and `ManovaEnsemble`.
+        bins (int or sequence, default=100): If bins is an integer, it defines the number of
+            equal-width bins in the range. If bins is a sequence, it defines the
+            bin edges, including the left edge of the first bin and the right
+            edge of the last bin; in this case, bins may be unequally spaced.
+        savefig_path (string, default=None): path to save the created figure. If it is not
+            provided, the plot is shown at the end of the routine.
     """
     # plotting ensemble spectral histogram
     observed, bin_edges = ensemble._plot_eigval_hist(bins=bins, density=True, normalize=True)

--- a/skrmt/ensemble/wishart_ensemble.py
+++ b/skrmt/ensemble/wishart_ensemble.py
@@ -8,7 +8,6 @@ and Wishart Quaternion Ensemble.
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy import sparse, special
 
 from .base_ensemble import _Ensemble

--- a/tutorial/plot_3_eigenvalue_independence.py
+++ b/tutorial/plot_3_eigenvalue_independence.py
@@ -1,0 +1,77 @@
+"""
+Eigenvalue Independence
+=======================
+
+In this tutorial, we highlight the fact that eigenvalues of a random matrix
+sample are *not* independent. However, random numbers sampled using the PDF
+of a spectral law (e.g. Wigner's Semicircle law) are actually drawn independently.
+
+"""
+
+# Author: Alejandro Santorum Varela
+# License: BSD 3-Clause
+
+##############################################################################
+# Independent random samples vs. eigenvalues of a random matrix sample
+# --------------------------------------------------------------------
+# 
+# Using **scikit-rmt** to simulate the behaviour of the ensembles, it is possible
+# to illustrate how the eigenvalues of a random matrix sample are not independent,
+# since they are draw from the same matrix sample. However, random variates sampled
+# using the PDF of a spectral law (for example, Wigner's Semicircle law) are drawn
+# independently.
+#
+# We can observe this phenomenon by plotting the **histogram of a random matrix**
+# alongside the PDF of the corresponding spectral law. This is easily done by using
+# the function ``plot_spectral_hist_and_law`` in ``skrmt.ensemble.utils``:
+
+from skrmt.ensemble.gaussian_ensemble import GaussianEnsemble
+from skrmt.ensemble.utils import plot_spectral_hist_and_law
+
+goe = GaussianEnsemble(beta=1, n=3000, use_tridiagonal=True)
+plot_spectral_hist_and_law(ensemble=goe, bins=60)
+
+##############################################################################
+# In the previous example, the histogram of the spectrum of a sample from
+# the Gaussian Ensemble was plotted next to the PDF of the Wigner's
+# Semicircle law.
+# 
+# It can be observed that the eigenvalues of a single sample of a random matrix 
+# are *not* independent since the fluctuations of the histogram compared to
+# Wigner's Semicircle PDF are really small. In contrast, if we compare independent
+# random samples from the Wigner Semicircle law and the actual PDF we observe
+# higher fluctuations for the *same sample size* (in this example, 3000).
+
+from skrmt.ensemble.spectral_law import WignerSemicircleDistribution
+
+wsd = WignerSemicircleDistribution(beta=1)
+wsd.plot_empirical_pdf(
+    sample_size=3000,
+    bins=60,
+    density=True,
+    plot_law_pdf=True
+)
+
+##############################################################################
+# Similarly, this can be seen for other ensembles. For example, with the
+# Wishart Ensemble.
+
+from skrmt.ensemble.wishart_ensemble import WishartEnsemble
+from skrmt.ensemble.utils import plot_spectral_hist_and_law
+
+wre = WishartEnsemble(beta=1, p=1000, n=3000, use_tridiagonal=True)
+plot_spectral_hist_and_law(ensemble=wre, bins=60)
+
+##############################################################################
+# The fluctuations with respect the PDF of the Marchenko-Pastur law are larger
+# if we directly draw independent random samples from that distribution:
+
+from skrmt.ensemble.spectral_law import MarchenkoPasturDistribution
+
+mpd = MarchenkoPasturDistribution(beta=1, ratio=3)
+mpd.plot_empirical_pdf(
+    sample_size=1000,
+    bins=60,
+    density=True,
+    plot_law_pdf=True
+)


### PR DESCRIPTION
Implement a new function in `skrmt.ensemble.utils` that plots the spectral histogram of a random matrix ensemble alongside the PDF of the corresponding spectral law. This is useful to compare **independent drawn samples from the spectral distributions** vs. computing the **eigenvalues (not independent) of samples of random matrices**.

The new function is called `plot_spectral_hist_and_law`.

In addition, the **methods plotting histograms in the ensemble classes** have been **slightly refactored**. 